### PR TITLE
repaire multi thread operate bankinate bugs

### DIFF
--- a/10-Code/SevenTiny.Bantina.Bankinate/MySqlDbContext.cs
+++ b/10-Code/SevenTiny.Bantina.Bankinate/MySqlDbContext.cs
@@ -27,7 +27,7 @@ namespace SevenTiny.Bantina.Bankinate
         {
             DbHelper.ConnString_Default = connectionString;
             DbHelper.DbType = DataBaseType.MySql;
-            MCache.ExpiredTimeSpan = CacheExpiredTimeSpan;
+            MCache.Instance.ExpiredTimeSpan = CacheExpiredTimeSpan;
         }
 
         public MySqlDbContext(string connectionString_Read, string connectionString_ReadWrite)
@@ -35,7 +35,7 @@ namespace SevenTiny.Bantina.Bankinate
             DbHelper.ConnString_R = connectionString_Read;
             DbHelper.ConnString_RW = connectionString_ReadWrite;
             DbHelper.DbType = DataBaseType.MySql;
-            MCache.ExpiredTimeSpan = CacheExpiredTimeSpan;
+            MCache.Instance.ExpiredTimeSpan = CacheExpiredTimeSpan;
         }
 
         public string SqlStatement { get; set; }
@@ -130,7 +130,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateAddSqlAndGetParams(entity);
 
-            MCache.MarkTableModifyAdd(TableName, entity);
+            MCache.Instance.MarkTableModifyAdd(TableName, entity);
 
             DbHelper.ExecuteNonQuery(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -141,7 +141,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateAddSqlAndGetParams(entity);
 
-            MCache.MarkTableModifyAdd(TableName, entity);
+            MCache.Instance.MarkTableModifyAdd(TableName, entity);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -162,7 +162,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"DELETE {filter.Parameters[0].Name} From {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            MCache.MarkTableModifyDelete(TableName, filter);
+            MCache.Instance.MarkTableModifyDelete(TableName, filter);
 
             DbHelper.ExecuteNonQuery(SqlStatement);
         }
@@ -173,7 +173,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"DELETE {filter.Parameters[0].Name} From {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            MCache.MarkTableModifyDelete(TableName, filter);
+            MCache.Instance.MarkTableModifyDelete(TableName, filter);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement);
         }
@@ -245,7 +245,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateUpdateSqlAndGetParams(filter, entity);
 
-            MCache.MarkTableModifyUpdate(TableName, filter, entity);
+            MCache.Instance.MarkTableModifyUpdate(TableName, filter, entity);
 
             DbHelper.ExecuteNonQuery(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -256,7 +256,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateUpdateSqlAndGetParams(filter, entity);
 
-            MCache.MarkTableModifyUpdate(TableName, filter, entity);
+            MCache.Instance.MarkTableModifyUpdate(TableName, filter, entity);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -267,7 +267,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT * FROM {TableName}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, null, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, null, () =>
               {
                   return DbHelper.ExecuteList<TEntity>(SqlStatement);
               }, out bool fromCache);
@@ -284,7 +284,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {orderBy.Parameters[0].Name} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, null, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, null, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -300,7 +300,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -317,7 +317,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -333,7 +333,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)} LIMIT 1";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntity(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entity(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteEntity<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -349,7 +349,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT COUNT(0) FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            var result = Convert.ToInt32(MCache.GetFromCacheIfNotExistReStoreCount(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = Convert.ToInt32(MCache.Instance.GetFromCacheIfNotExistReStore_Count(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteScalar(SqlStatement);
             }, out bool fromCache));
@@ -366,13 +366,13 @@ namespace SevenTiny.Bantina.Bankinate
 
         public void ExecuteSql(string sqlStatement, IDictionary<string, object> parms = null)
         {
-            MCache.MarkTableModify(TableName);
+            MCache.Instance.MarkTableModify(TableName);
             DbHelper.ExecuteNonQuery(sqlStatement, System.Data.CommandType.Text, parms);
         }
 
         public void ExecuteSqlAsync(string sqlStatement, IDictionary<string, object> parms = null)
         {
-            MCache.MarkTableModify(TableName);
+            MCache.Instance.MarkTableModify(TableName);
             DbHelper.ExecuteNonQueryAsync(sqlStatement, System.Data.CommandType.Text, parms);
         }
 
@@ -408,7 +408,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {orderBy.Parameters[0].Name} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc} LIMIT {pageIndex * pageSize},{pageSize}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int count, out bool fromCache);
@@ -435,7 +435,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc} LIMIT {pageIndex * pageSize},{pageSize}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int count, out bool fromCache);
@@ -462,7 +462,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {orderBy.Parameters[0].Name} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc} LIMIT {pageIndex * pageSize},{pageSize}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int cou, out bool fromCache);
@@ -481,7 +481,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {LambdaToSql.ConvertWhere(filter)} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc} LIMIT {pageIndex * pageSize},{pageSize}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int cou, out bool fromCache);

--- a/10-Code/SevenTiny.Bantina.Bankinate/SqlServerDbContext.cs
+++ b/10-Code/SevenTiny.Bantina.Bankinate/SqlServerDbContext.cs
@@ -27,7 +27,7 @@ namespace SevenTiny.Bantina.Bankinate
         {
             DbHelper.ConnString_Default = connectionString;
             DbHelper.DbType = DataBaseType.SqlServer;
-            MCache.ExpiredTimeSpan = CacheExpiredTimeSpan;
+            MCache.Instance.ExpiredTimeSpan = CacheExpiredTimeSpan;
         }
 
         public SqlServerDbContext(string connectionString_Read, string connectionString_ReadWrite)
@@ -35,7 +35,7 @@ namespace SevenTiny.Bantina.Bankinate
             DbHelper.ConnString_R = connectionString_Read;
             DbHelper.ConnString_RW = connectionString_ReadWrite;
             DbHelper.DbType = DataBaseType.SqlServer;
-            MCache.ExpiredTimeSpan = CacheExpiredTimeSpan;
+            MCache.Instance.ExpiredTimeSpan = CacheExpiredTimeSpan;
         }
 
         public string SqlStatement { get; set; }
@@ -130,7 +130,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateAddSqlAndGetParams(entity);
 
-            MCache.MarkTableModifyAdd(TableName, entity);
+            MCache.Instance.MarkTableModifyAdd(TableName, entity);
 
             DbHelper.ExecuteNonQuery(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -141,7 +141,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateAddSqlAndGetParams(entity);
 
-            MCache.MarkTableModifyAdd(TableName, entity);
+            MCache.Instance.MarkTableModifyAdd(TableName, entity);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -162,7 +162,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"DELETE {filter.Parameters[0].Name} From {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            MCache.MarkTableModifyDelete(TableName, filter);
+            MCache.Instance.MarkTableModifyDelete(TableName, filter);
 
             DbHelper.ExecuteNonQuery(SqlStatement);
         }
@@ -173,7 +173,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"DELETE {filter.Parameters[0].Name} From {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            MCache.MarkTableModifyDelete(TableName, filter);
+            MCache.Instance.MarkTableModifyDelete(TableName, filter);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement);
         }
@@ -243,7 +243,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateUpdateSqlAndGetParams(filter, entity);
 
-            MCache.MarkTableModifyUpdate(TableName, filter, entity);
+            MCache.Instance.MarkTableModifyUpdate(TableName, filter, entity);
 
             DbHelper.ExecuteNonQuery(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -254,7 +254,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             Dictionary<string, object> paramsDic = GenerateUpdateSqlAndGetParams(filter, entity);
 
-            MCache.MarkTableModifyUpdate(TableName, filter, entity);
+            MCache.Instance.MarkTableModifyUpdate(TableName, filter, entity);
 
             DbHelper.ExecuteNonQueryAsync(SqlStatement, System.Data.CommandType.Text, paramsDic);
         }
@@ -265,7 +265,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT * FROM {TableName}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, null, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, null, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -282,7 +282,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {orderBy.Parameters[0].Name} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, null, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, null, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -298,7 +298,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -315,7 +315,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)} ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntities(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entities(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -332,7 +332,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT TOP 1 * FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntity(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStore_Entity(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteEntity<TEntity>(SqlStatement);
             }, out bool fromCache);
@@ -348,7 +348,7 @@ namespace SevenTiny.Bantina.Bankinate
 
             this.SqlStatement = $"SELECT COUNT(0) FROM {TableName} {filter.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}";
 
-            var result = Convert.ToInt32(MCache.GetFromCacheIfNotExistReStoreCount(LocalCache, TableName, SqlStatement, filter, () =>
+            var result = Convert.ToInt32(MCache.Instance.GetFromCacheIfNotExistReStore_Count(LocalCache, TableName, SqlStatement, filter, () =>
             {
                 return DbHelper.ExecuteScalar(SqlStatement);
             }, out bool fromCache));
@@ -365,13 +365,13 @@ namespace SevenTiny.Bantina.Bankinate
 
         public void ExecuteSql(string sqlStatement, IDictionary<string, object> parms = null)
         {
-            MCache.MarkTableModify(TableName);
+            MCache.Instance.MarkTableModify(TableName);
             DbHelper.ExecuteNonQuery(sqlStatement, System.Data.CommandType.Text, parms);
         }
 
         public void ExecuteSqlAsync(string sqlStatement, IDictionary<string, object> parms = null)
         {
-            MCache.MarkTableModify(TableName);
+            MCache.Instance.MarkTableModify(TableName);
             DbHelper.ExecuteNonQueryAsync(sqlStatement, System.Data.CommandType.Text, parms);
         }
 
@@ -412,7 +412,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT TOP {pageSize} * FROM (SELECT ROW_NUMBER() OVER (ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}) AS RowNumber,* FROM {TableName} {orderBy.Parameters[0].Name} WHERE 1=1) AS TTTTTT  WHERE RowNumber > {pageSize * (pageIndex - 1)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int count, out bool fromCache);
@@ -439,7 +439,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT TOP {pageSize} * FROM (SELECT ROW_NUMBER() OVER (ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}) AS RowNumber,* FROM {TableName} {orderBy.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}) AS TTTTTT  WHERE RowNumber > {pageSize * (pageIndex - 1)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int count, out bool fromCache);
@@ -466,7 +466,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT TOP {pageSize} * FROM (SELECT ROW_NUMBER() OVER (ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}) AS RowNumber,* FROM {TableName} {orderBy.Parameters[0].Name} WHERE 1=1) AS TTTTTT  WHERE RowNumber > {pageSize * (pageIndex - 1)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, null, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int cou, out bool fromCache);
@@ -495,7 +495,7 @@ namespace SevenTiny.Bantina.Bankinate
             string desc = isDESC ? "DESC" : "ASC";
             this.SqlStatement = $"SELECT TOP {pageSize} * FROM (SELECT ROW_NUMBER() OVER (ORDER BY {LambdaToSql.ConvertOrderBy(orderBy)} {desc}) AS RowNumber,* FROM {TableName} {orderBy.Parameters[0].Name} {LambdaToSql.ConvertWhere(filter)}) AS TTTTTT  WHERE RowNumber > {pageSize * (pageIndex - 1)}";
 
-            var result = MCache.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
+            var result = MCache.Instance.GetFromCacheIfNotExistReStoreEntitiesPaging(LocalCache, TableName, SqlStatement, filter, pageIndex, pageSize, orderBy, isDESC, () =>
             {
                 return DbHelper.ExecuteList<TEntity>(SqlStatement);
             }, out int cou, out bool fromCache);

--- a/10-Code/Test.SevenTiny.Bantina.ConsoleApp/BankinateTest.cs
+++ b/10-Code/Test.SevenTiny.Bantina.ConsoleApp/BankinateTest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Test.SevenTiny.Bantina.Model;
 using static Newtonsoft.Json.JsonConvert;
@@ -13,7 +14,7 @@ namespace Test.SevenTiny.Bantina.ConsoleApp
     {
         public static void Test()
         {
-            SqlServerTest();
+            BankinateCacheTest();
         }
 
         private static void MongoDbTest()
@@ -63,10 +64,11 @@ namespace Test.SevenTiny.Bantina.ConsoleApp
         private static void BankinateCacheTest()
         {
             int i = 0;
-            var result1 = StopwatchHelper.Caculate(3, () =>
+            var result1 = StopwatchHelper.Caculate(100, () =>
             {
                 using (var db = new MySqlTestDbContext())
                 {
+                    Thread.Sleep(1000);
                     i++;
                     //Task.Run(() =>
                     //{
@@ -94,28 +96,28 @@ namespace Test.SevenTiny.Bantina.ConsoleApp
 
                     Console.WriteLine(db.IsFromCache);
 
-                    var stu4 = db.QueryOne<Student>(t => t.Id == 207);
+                    //var stu4 = db.QueryOne<Student>(t => t.Id == 207);
 
-                    Console.WriteLine(db.IsFromCache);
+                    //Console.WriteLine(db.IsFromCache);
 
-                    var stu5 = db.QueryList<Student>(t => t.Name.StartsWith("monk"));
+                    //var stu5 = db.QueryList<Student>(t => t.Name.StartsWith("monk"));
 
-                    Console.WriteLine(db.IsFromCache);
+                    //Console.WriteLine(db.IsFromCache);
 
-                    var stu6 = db.QueryOne<Student>(t => t.Name.Contains("m"));
+                    //var stu6 = db.QueryOne<Student>(t => t.Name.Contains("m"));
 
-                    Console.WriteLine(db.IsFromCache);
+                    //Console.WriteLine(db.IsFromCache);
 
-                    var c3 = db.QueryCount<Student>(t => t.Name.EndsWith("3"));
+                    //var c3 = db.QueryCount<Student>(t => t.Name.EndsWith("3"));
 
-                    Console.WriteLine(db.IsFromCache);
+                    //Console.WriteLine(db.IsFromCache);
 
-                    var stu7 = db.QueryOne<Student>(t => t.Name.Contains("k"));
+                    //var stu7 = db.QueryOne<Student>(t => t.Name.Contains("k"));
 
-                    Console.WriteLine(db.IsFromCache);
+                    //Console.WriteLine(db.IsFromCache);
 
-                    var list2 = db.QueryListPaging<Student>(1, 2, t => t.GradeId, true);
-                    Console.WriteLine("paging " + db.IsFromCache);
+                    //var list2 = db.QueryListPaging<Student>(1, 2, t => t.GradeId, true);
+                    //Console.WriteLine("paging " + db.IsFromCache);
                 }
             });
             Console.WriteLine();

--- a/10-Code/Test.SevenTiny.Bantina.Model/MySqlTestDbContext.cs
+++ b/10-Code/Test.SevenTiny.Bantina.Model/MySqlTestDbContext.cs
@@ -7,7 +7,7 @@ namespace Test.SevenTiny.Bantina.Model
 {
     public class MySqlTestDbContext : MySqlDbContext<MySqlTestDbContext>
     {
-        public MySqlTestDbContext() : base("xxx")
+        public MySqlTestDbContext() : base("")
         {
             LocalCache = true;
         }


### PR DESCRIPTION
多线程操作，每次扫描key不存在就Task.Run一个新的线程去后台扫描，然后还用lock进行了线程锁。
这样的操作就会导致一大波task在那等待，即使扫描完也会将前面堆积的task进行执行，严重浪费了系统资源。

改进：

在外层再加一层判断过滤当前状态是否处于扫描状态，如果处于扫描状态，就不新开前程，而等待前面第一个正在扫描的线程执行。这样的结果就是后台只有一个线程在扫描库，而不会同时等待很多。始终有一个扫描库。