### PR TITLE
repaire bug of bankinate attribute get null exception :tomato:

### DIFF
--- a/10-Code/SevenTiny.Bantina.Bankinate/Attributes/ColumnAttribute.cs
+++ b/10-Code/SevenTiny.Bantina.Bankinate/Attributes/ColumnAttribute.cs
@@ -32,8 +32,8 @@ namespace SevenTiny.Bantina.Bankinate.Attributes
 
         public static string GetName(Type type)
         {
-            var attr = type.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault();
-            return (attr as ColumnAttribute).Name ?? type.Name;
+            var attr = type.GetCustomAttributes(typeof(ColumnAttribute), true)?.FirstOrDefault();
+            return (attr as ColumnAttribute)?.Name ?? type.Name;
         }
     }
 }

--- a/10-Code/SevenTiny.Bantina.Bankinate/Attributes/DataBaseAttribute.cs
+++ b/10-Code/SevenTiny.Bantina.Bankinate/Attributes/DataBaseAttribute.cs
@@ -29,8 +29,8 @@ namespace SevenTiny.Bantina.Bankinate.Attributes
 
         public static string GetName(Type type)
         {
-            var attr = type.GetCustomAttributes(typeof(DataBaseAttribute), true).FirstOrDefault();
-            return (attr as DataBaseAttribute).Name ?? type.Name;
+            var attr = type.GetCustomAttributes(typeof(DataBaseAttribute), true)?.FirstOrDefault();
+            return (attr as DataBaseAttribute)?.Name ?? type.Name;
         }
     }
 }

--- a/10-Code/SevenTiny.Bantina.Bankinate/Attributes/TableAttribute.cs
+++ b/10-Code/SevenTiny.Bantina.Bankinate/Attributes/TableAttribute.cs
@@ -30,8 +30,8 @@ namespace SevenTiny.Bantina.Bankinate.Attributes
 
         public static string GetName(Type type)
         {
-            var attr = type.GetCustomAttributes(typeof(TableAttribute), true).FirstOrDefault();
-            return (attr as TableAttribute).Name ?? type.Name;
+            var attr = type.GetCustomAttributes(typeof(TableAttribute), true)?.FirstOrDefault();
+            return (attr as TableAttribute)?.Name ?? type.Name;
         }
     }
 }


### PR DESCRIPTION
如果Table类没有添加标签的话，不能降级获取类名作为表名，这里作了降级处理
提升了代码健壮性，添加了列特性标签获取时的降级处理